### PR TITLE
chore: correct python requires & version bump

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = unexpected_isaves
-version = 1.2.1
+version = 1.2.2
 author = Eric Mendes
 author_email = ericvelasco.2000@gmail.com
 description = Python library that paints an image on a spreadsheet or builds its pixel art in Minecraft.
@@ -18,7 +18,7 @@ classifiers =
 package_dir =
     = src
 packages = find:
-python_requires = >=3.9
+python_requires = >=3.8
 install_requires =
     pandas>=1.3.5
     numpy>=1.21.5


### PR DESCRIPTION
It makes no sense for this to only accept Python 3.9 and upper as it works just fine with 3.8 too.